### PR TITLE
Add phpstan at level 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
   "require-dev": {
     "roave/security-advisories": "dev-latest",
     "squizlabs/php_codesniffer": "^3.7",
-    "phpcompatibility/php-compatibility": "^9.3"
+    "phpcompatibility/php-compatibility": "^9.3",
+    "phpstan/phpstan": "^1.9"
   },
   "repositories": [
     {
@@ -42,6 +43,7 @@
   "scripts": {
     "sniffer:php7.4": "phpcs -p ./lib --standard=vendor/phpcompatibility/php-compatibility/PHPCompatibility --runtime-set testVersion 7.4",
     "sniffer:php8.0": "phpcs -p ./lib --standard=vendor/phpcompatibility/php-compatibility/PHPCompatibility --runtime-set testVersion 8.0",
-    "sniffer:php8.1": "phpcs -p ./lib --standard=vendor/phpcompatibility/php-compatibility/PHPCompatibility --runtime-set testVersion 8.1"
+    "sniffer:php8.1": "phpcs -p ./lib --standard=vendor/phpcompatibility/php-compatibility/PHPCompatibility --runtime-set testVersion 8.1",
+    "phpstan": "phpstan"
   }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,4 @@
+parameters:
+  level: 5
+  paths:
+    - lib


### PR DESCRIPTION
Adding PHPStan and set level to 5.

It would also be possible to use a higher level and use a phpstan baseline.
I tested it and level 6 will add 13 errors (mostly because of untyped/generic arrays), but other than that, it works fine up to level 8 

So the question is: highest supported level without fixes & baseline or higher level + baseline.
What do you think?